### PR TITLE
SnapshotsEp for AppInstance and RemoteProvider

### DIFF
--- a/pkg/dsdk/app_instances.go
+++ b/pkg/dsdk/app_instances.go
@@ -35,10 +35,12 @@ type AppInstance struct {
 	TemplateOverride        map[string]interface{}  `json:"template_override,omitempty" mapstructure:"template_override"`
 	Uuid                    string                  `json:"uuid,omitempty" mapstructure:"uuid"`
 	StorageInstancesEp      *StorageInstances       `json:"-"`
+	SnapshotsEp             *Snapshots              `json:"-"`
 }
 
 func RegisterAppInstanceEndpoints(a *AppInstance) {
 	a.StorageInstancesEp = newStorageInstances(a.Path)
+	a.SnapshotsEp = newSnapshots(a.Path)
 	for _, si := range a.StorageInstances {
 		RegisterStorageInstanceEndpoints(si)
 	}

--- a/pkg/dsdk/remote_provider.go
+++ b/pkg/dsdk/remote_provider.go
@@ -26,10 +26,12 @@ type RemoteProvider struct {
 	Host              string                   `json:"host,omitempty" mapstructure:"host"`
 	Port              string                   `json:"port,omitempty" mapstructure:"port"`
 	OperationsEp      string
+	SnapshotsEp       *Snapshots
 }
 
-func RegisterRemoteProviderEndpoints(a *RemoteProvider) {
+func RegisterRemoteProviderEndpoints(rp *RemoteProvider) {
 	//a.OperationsEp = newOperations(a.Path)
+	rp.SnapshotsEp = newSnapshots(rp.Path)
 }
 
 type RemoteProviders struct {


### PR DESCRIPTION
- Adds the `Snapshots` object that can be used for creating/listing/getting snapshots to `AppInstance` and `RemoteProvider` structs.
- Adds a test case similar to the volume snapshot test case
- Adds a test helper method like the `createAi` helper for handling `RemoteProvider` setup/teardown
- Fixes some typos in the other test cases (just debugging output stating the test name).