### PR TITLE
Stash the filter Param and reuse it when auto-paging

### DIFF
--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -334,7 +334,7 @@ func (c *ApiConnection) GetList(ctxt context.Context, url string, ro *greq.Reque
 		offset := 0
 		tcnt := 0
 		for ldata := len(data); ldata != tcnt; {
-			tcnt := int(rs.Metadata["total_count"].(float64))
+			tcnt := int(rs.Metadata["request_count"].(float64))
 			offset += len(rs.Data)
 			if offset >= tcnt {
 				break

--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -319,6 +319,12 @@ func (c *ApiConnection) GetList(ctxt context.Context, url string, ro *greq.Reque
 	rs := &ApiListOuter{}
 	apiresp, err := c.doWithAuth(ctxt, "GET", url, ro, rs)
 	// TODO:(_alastor_) handle pulling paged entries
+
+	filterparam := ""
+	if ro.Params != nil && len(ro.Params) > 0 {
+		filterparam = ro.Params["filter"]
+	}
+
 	if apiresp == nil && len(rs.Metadata) > 0 {
 		lp := ListParamsFromMap(ro.Params)
 		if lp.Limit != 0 || lp.Offset != 0 {
@@ -335,6 +341,7 @@ func (c *ApiConnection) GetList(ctxt context.Context, url string, ro *greq.Reque
 			}
 			ro.Params = ListParams{
 				Offset: offset,
+				Filter: filterparam,
 			}.ToMap()
 			rs.Data = []interface{}{}
 			apiresp, err := c.doWithAuth(ctxt, "GET", url, ro, rs)


### PR DESCRIPTION
Passing a filter to listing operations would successfully use the filter but the following for loop would detect that there were less elements retrieved than the full result count and discard the filter. Example response for the first request looks like the following:

```
  "data": [
   {...}
  ],
  "metadata": {
    "limit": 100,
    "total_count": 22,
    "request_count": 1
  }
```

Seeing that `tcnt` (`metadata.total_count`) is less than the number of elements in `data` the loop automatically requests the next page but fails to keep the original filter. This results in additional results that would not have been included based on the filter originally passed in.

# Change
- Stash the originally passed in `Filter` and reuse it on subsequent requests
- Base the expected number of results on the `request_count` parameter which is equal to the `total_count` when no filter is used and indicates the actual number of filtered results when a filter is used.