### PR TITLE
Add TsVersion field to Snapshot struct

### DIFF
--- a/pkg/dsdk/snapshots.go
+++ b/pkg/dsdk/snapshots.go
@@ -20,6 +20,7 @@ type Snapshot struct {
 	EffectiveSize   int               `json:"effective_size,omitempty" mapstructure:"effective_size"`
 	Local           bool              `json:"local,omitempty" mapstructure:"local"`
 	AppStructure    interface{}       `json:"app_structure,omitempty" mapstructure:"app_structure"`
+	TsVersion       string            `json:"ts_version,omitempty" mapstructure:"ts_version"`
 }
 
 type Snapshots struct {


### PR DESCRIPTION
This field is populated when listing snapshots through the `GET /remote_provider/:uuid/snapshots` endpoint and is needed for the clone endpoint (`PUT /remote_provider/:uuid/snapshots/:ts_version`).