### PR TITLE
Update authentication in request headers after session refresh

### DIFF
--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -256,6 +256,7 @@ func (c *ApiConnection) do(ctxt context.Context, method, url string, ro *greq.Re
 			Log().Errorf("%s", err2)
 			return apiresp, err2
 		}
+		ro.Headers["Auth-Token"] = c.apikey
 		return c.do(ctxt, method, url, ro, rs, false, sensitive)
 	}
 	if err == badStatus[Retry503] || err == badStatus[ConnectionError] {


### PR DESCRIPTION
Fixes `ApiConnection.do` so that the updated apikey is used when retrying a request that failed due to an expired session. Subsequent requests will pick up the new API key but the headers prepared for the failed request were not being updated.