### PR TITLE
Hiding CHAP credentials

### DIFF
--- a/pkg/dsdk/connection.go
+++ b/pkg/dsdk/connection.go
@@ -290,6 +290,10 @@ func (c *ApiConnection) do(ctxt context.Context, method, url string, ro *greq.Re
 	if err != nil {
 		Log().Errorf("Couldn't stringify data, %s", ro.JSON)
 	}
+	// Strip all CHAP credentails before printing to logs
+	if strings.Contains(string(sdata), "target_user_name") == true {
+		sdata = []byte("********")
+	}
 	if sensitive {
 		sdata = []byte("********")
 	}


### PR DESCRIPTION
1) Replace the request options with *** if CHAP credentials are found.
2) Remove duplicate debug statement that prints to driver logs.